### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/app/src/cmd/current.rs
+++ b/src/app/src/cmd/current.rs
@@ -65,7 +65,7 @@ impl<'a, 'b> CommandAsyncTrait<'a, 'b> for CurrentCmd {
 
         let name = matches.value_of("name").unwrap();
         if !pkg_service.has(name)? {
-            return Err(anyhow!("{} not installed"));
+            return Err(anyhow!("{} not installed", name));
         }
 
         let pkg = pkg_service.get(name)?;


### PR DESCRIPTION
Without this, the error message would literally be "{} not installed" with curly braces in it instead of the package name.