### PR TITLE
Update viddy.rs asset template

### DIFF
--- a/crates/generator/src/pkg/viddy.rs
+++ b/crates/generator/src/pkg/viddy.rs
@@ -11,7 +11,7 @@ pub fn release() -> Package {
         detail: None,
         targets: vec![
             PackageTargetType::LinuxAmd64(PackageManagement {
-                artifact_templates: vec!["viddy_{version}_Linux_x86_64.tar.gz".to_string()],
+                artifact_templates: vec!["viddy_Linux_x86_64.tar.gz".to_string()],
                 executable_templates: None,
                 executable_mappings: None,
                 install_commands: None,
@@ -21,7 +21,7 @@ pub fn release() -> Package {
                 scan_dirs: None,
             }),
             PackageTargetType::MacOS(PackageManagement {
-                artifact_templates: vec!["viddy_{version}_Darwin_x86_64.tar.gz".to_string()],
+                artifact_templates: vec!["viddy_Darwin_x86_64.tar.gz".to_string()],
                 executable_templates: None,
                 executable_mappings: None,
                 install_commands: None,
@@ -31,7 +31,7 @@ pub fn release() -> Package {
                 scan_dirs: None,
             }),
             PackageTargetType::Windows(PackageManagement {
-                artifact_templates: vec!["viddy_{version}_Windows_x86_64.tar.gz".to_string()],
+                artifact_templates: vec!["viddy_Windows_x86_64.tar.gz".to_string()],
                 executable_templates: None,
                 executable_mappings: None,
                 install_commands: None,


### PR DESCRIPTION
Since version 0.3.7 viddy changed the naming of the releases' assets to remove version from filename